### PR TITLE
Consolidate compute service init and start settings

### DIFF
--- a/alchemiscale_fah/cli.py
+++ b/alchemiscale_fah/cli.py
@@ -262,16 +262,11 @@ def fah_asynchronous(config_file):
 
     params = yaml.safe_load(config_file)
 
-    params_init = params.get("init", {})
-    params_start = params.get("start", {})
-
-    if "scopes" in params_init:
-        params_init["scopes"] = [
-            Scope.from_str(scope) for scope in params_init["scopes"]
-        ]
+    if "scopes" in params:
+        params["scopes"] = [Scope.from_str(scope) for scope in params["scopes"]]
 
     service = FahAsynchronousComputeService(
-        FahAsynchronousComputeServiceSettings(**params_init)
+        FahAsynchronousComputeServiceSettings(**params)
     )
 
     # add signal handling
@@ -284,6 +279,6 @@ def fah_asynchronous(config_file):
         signal.signal(getattr(signal, signame), stop)
 
     try:
-        service.start(**params_start)
+        service.start()
     except KeyboardInterrupt:
         pass

--- a/alchemiscale_fah/compute/service.py
+++ b/alchemiscale_fah/compute/service.py
@@ -63,6 +63,8 @@ class FahAsynchronousComputeService(SynchronousComputeService):
         self.sleep_interval = self.settings.sleep_interval
         self.heartbeat_interval = self.settings.heartbeat_interval
         self.claim_limit = self.settings.claim_limit
+        self.max_tasks = self.settings.max_tasks
+        self.max_time = self.settings.max_time
 
         self.client = AlchemiscaleComputeClient(
             self.settings.api_url,
@@ -355,23 +357,19 @@ class FahAsynchronousComputeService(SynchronousComputeService):
 
         return result_sks
 
-    def start(self, max_tasks: Optional[int] = None, max_time: Optional[int] = None):
+    def start(self):
         """Start the service.
 
-        Limits to the maximum number of executed tasks or seconds to run for
-        can be set. The first maximum to be hit will trigger the service to
-        exit.
-
-        Parameters
-        ----------
-        max_tasks
-            Max number of Tasks to execute before exiting.
-            If `None`, the service will have no task limit.
-        max_time
-            Max number of seconds to run before exiting.
-            If `None`, the service will have no time limit.
+        The service runs until it is told to stop, or until one of the limits
+        configured on its settings is reached. ``max_tasks`` caps the number of
+        Tasks executed and ``max_time`` caps the number of seconds run; the
+        first maximum to be hit triggers the service to exit. Either limit being
+        ``None`` (the default) means no limit of that kind.
 
         """
+        max_tasks = self.max_tasks
+        max_time = self.max_time
+
         self._stop = False
         self.cycle_init()
 

--- a/alchemiscale_fah/tests/integration/test_cli.py
+++ b/alchemiscale_fah/tests/integration/test_cli.py
@@ -151,27 +151,25 @@ def compute_service_config(compute_api_args, fah_client_preloaded):
     fahc: FahAdaptiveSamplingClient = fah_client_preloaded
 
     config = {
-        "init": {
-            "api_url": f"http://{host}:{port}",
-            "identifier": "test-compute-user",
-            "key": "test-comute-user-key",
-            "name": "test-compute-service",
-            "shared_basedir": "./shared",
-            "scratch_basedir": "./scratch",
-            "loglevel": "INFO",
-            "fah_as_url": fahc.as_url,
-            "fah_ws_url": fahc.ws_url,
-            "fah_certificate_file": str(fahc.certificate_file),
-            "fah_key_file": str(fahc.key_file),
-            "fah_csr_file": str(fahc.csr_file),
-            "fah_client_verify": False,
-            "fah_cert_update_interval": 2,
-            "index_dir": "./index/index_dir",
-            "obj_store": "./index/object_store",
-            "fah_project_ids": [90001],
-            "fah_core_ids_supported": ["0x23"],
-        },
-        "start": {"max_time": None},
+        "api_url": f"http://{host}:{port}",
+        "identifier": "test-compute-user",
+        "key": "test-comute-user-key",
+        "name": "test-compute-service",
+        "shared_basedir": "./shared",
+        "scratch_basedir": "./scratch",
+        "loglevel": "INFO",
+        "fah_as_url": fahc.as_url,
+        "fah_ws_url": fahc.ws_url,
+        "fah_certificate_file": str(fahc.certificate_file),
+        "fah_key_file": str(fahc.key_file),
+        "fah_csr_file": str(fahc.csr_file),
+        "fah_client_verify": False,
+        "fah_cert_update_interval": 2,
+        "index_dir": "./index/index_dir",
+        "obj_store": "./index/object_store",
+        "fah_project_ids": [90001],
+        "fah_core_ids_supported": ["0x23"],
+        "max_time": None,
     }
 
     return config
@@ -185,8 +183,8 @@ def test_compute_fahasynchronous(
 
     # create compute identity; add all scope access
     identity = CredentialedComputeIdentity(
-        identifier=compute_service_config["init"]["identifier"],
-        hashed_key=hash_key(compute_service_config["init"]["key"]),
+        identifier=compute_service_config["identifier"],
+        hashed_key=hash_key(compute_service_config["key"]),
     )
 
     n4js.create_credentialed_entity(identity)
@@ -211,7 +209,7 @@ def test_compute_fahasynchronous(
 
             q = f"""
             match (csreg:ComputeServiceRegistration)
-            where csreg.identifier =~ "{compute_service_config['init']['name']}.*"
+            where csreg.identifier =~ "{compute_service_config['name']}.*"
             return csreg
             """
             while True:

--- a/devtools/configs/fah-asynchronous-compute-settings.yaml
+++ b/devtools/configs/fah-asynchronous-compute-settings.yaml
@@ -1,148 +1,142 @@
 ---
-# options for service initialization
-init:
+# URL of the compute API to execute Tasks for.
+api_url: https://compute.alchemiscale-instance.localdomain
 
-  # URL of the compute API to execute Tasks for.
-  api_url: https://compute.alchemiscale-instance.localdomain
+# Identifier for the compute identity used for authentication.
+identifier: compute-identity
 
-  # Identifier for the compute identity used for authentication.
-  identifier: compute-identity
+# Credential for the compute identity used for authentication.
+key: "compute-identity-key"
 
-  # Credential for the compute identity used for authentication.
-  key: "compute-identity-key"
+# The name to give this compute service; used for Task provenance, so
+# typically set to a distinct value to distinguish different compute
+# resources, e.g. different hosts or HPC clusters.
+name: compute-resource-name
 
-  # The name to give this compute service; used for Task provenance, so
-  # typically set to a distinct value to distinguish different compute
-  # resources, e.g. different hosts or HPC clusters.
-  name: compute-resource-name
-  
-  # Filesystem path to use for `ProtocolDAG` `shared` space.
-  shared_basedir: "./shared"
+# Filesystem path to use for `ProtocolDAG` `shared` space.
+shared_basedir: "./shared"
 
-  # Filesystem path to use for `ProtocolUnit` `scratch` space.
-  scratch_basedir: "./scratch"
+# Filesystem path to use for `ProtocolUnit` `scratch` space.
+scratch_basedir: "./scratch"
 
-  # If True, don't remove shared directories for `ProtocolDAG`s after
-  # completion.
-  keep_shared: False
+# If True, don't remove shared directories for `ProtocolDAG`s after
+# completion.
+keep_shared: False
 
-  # If True, don't remove scratch directories for `ProtocolUnit`s after
-  # completion.
-  keep_scratch: False
+# If True, don't remove scratch directories for `ProtocolUnit`s after
+# completion.
+keep_scratch: False
 
-  # Number of times to attempt a given Task on failure
-  n_retries: 3
+# Number of times to attempt a given Task on failure
+n_retries: 3
 
-  # Time in seconds to sleep if no Tasks claimed from compute API.
-  sleep_interval: 30
+# Time in seconds to sleep if no Tasks claimed from compute API.
+sleep_interval: 30
 
-  # Frequency at which to send heartbeats to compute API.
-  heartbeat_interval: 300
+# Frequency at which to send heartbeats to compute API.
+heartbeat_interval: 300
 
-  # Scopes to limit Task claiming to; defaults to all Scopes accessible by
-  # compute identity.
-  scopes:
-    - '*-*-*'
+# Scopes to limit Task claiming to; defaults to all Scopes accessible by
+# compute identity.
+scopes:
+  - '*-*-*'
 
-  # List giving names of Protocols to run with this service;
-  # `null` means no restriction
-  protocols:
-    - "FahNonEquilibriumCyclingProtocol"
+# List giving names of Protocols to run with this service;
+# `null` means no restriction
+protocols:
+  - "FahNonEquilibriumCyclingProtocol"
 
-  # Maximum number of Tasks to claim at a time from a TaskHub.
-  claim_limit: 1000
+# Maximum number of Tasks to claim at a time from a TaskHub.
+claim_limit: 1000
 
-  # The loglevel at which to report via STDOUT; see the :mod:`logging` docs for
-  # available levels.
-  loglevel: 'WARN'
+# Maximum number of Tasks to execute before exiting. If `null`, the service
+# will have no task limit.
+max_tasks: null
 
-  # Path to file for logging output; if not set, logging will only go to
-  # STDOUT.
-  logfile: null
+# Maximum number of seconds to run before exiting. If `null`, the service will
+# have no time limit.
+max_time: null
 
-  # Location of the cache directory as either a `pathlib.Path` or `str`.
-  # If ``None`` is provided then the directory will be determined via
-  # the ``XDG_CACHE_HOME`` environment variable or default to
-  # ``${HOME}/.cache/alchemiscale``. Default ``None``.
-  client_cache_directory: null
+# The loglevel at which to report via STDOUT; see the :mod:`logging` docs for
+# available levels.
+loglevel: 'WARN'
 
-  # Maximum size of the client cache in bytes. Default 1 GiB.
-  client_cache_size_limit: 1073741824
+# Path to file for logging output; if not set, logging will only go to
+# STDOUT.
+logfile: null
 
-  # Whether or not to use the local cache on disk.
-  client_use_local_cache: false
+# Location of the cache directory as either a `pathlib.Path` or `str`.
+# If ``None`` is provided then the directory will be determined via
+# the ``XDG_CACHE_HOME`` environment variable or default to
+# ``${HOME}/.cache/alchemiscale``. Default ``None``.
+client_cache_directory: null
 
-  # Maximum number of times to retry a request. In the case the API service is
-  # unresponsive an expoenential backoff is applied with retries until this
-  # number is reached. If set to -1, retries will continue indefinitely until
-  # success.
-  client_max_retries: 5
+# Maximum size of the client cache in bytes. Default 1 GiB.
+client_cache_size_limit: 1073741824
 
-  # The base number of seconds to use for exponential backoff. Must be greater
-  # than 1.0. 
-  client_retry_base_seconds: 2.0
- 
-  # Maximum number of seconds to sleep between retries; avoids runaway
-  # exponential backoff while allowing for many retries.
-  client_retry_max_seconds: 60.0
+# Whether or not to use the local cache on disk.
+client_use_local_cache: false
 
-  # Whether to verify SSL certificate presented by the API server.
-  client_verify: true
+# Maximum number of times to retry a request. In the case the API service is
+# unresponsive an expoenential backoff is applied with retries until this
+# number is reached. If set to -1, retries will continue indefinitely until
+# success.
+client_max_retries: 5
 
-  ## FAH-specific settings
+# The base number of seconds to use for exponential backoff. Must be greater
+# than 1.0.
+client_retry_base_seconds: 2.0
 
-  # Maximum number of workers to allocate to the service's process pool;
-  # `null` will default to number of processors on host.
-  max_processpool_workers: null
+# Maximum number of seconds to sleep between retries; avoids runaway
+# exponential backoff while allowing for many retries.
+client_retry_max_seconds: 60.0
 
-  # URL of the FAH assignment server to use.
-  fah_as_url: "https://assign1.foldingathome.org"
+# Whether to verify SSL certificate presented by the API server.
+client_verify: true
 
-  # URL of the FAH work server to use.
-  fah_ws_url: "https://<my-work-server>.foldingathome.org"
+## FAH-specific settings
 
-  # Path to the TLS certificate to use for authentication with FAH servers;
-  # required for real deployments.
-  fah_certificate_file: "./path/to/fah-cert.pem"
+# Maximum number of workers to allocate to the service's process pool;
+# `null` will default to number of processors on host.
+max_processpool_workers: null
 
-  # Path to the RSA private key used for TLS communication with FAH servers;
-  # required for real deployments.
-  fah_key_file: "./path/to/fah-key.pem"
-  
-  # Path to the certificate signing request (CSR) file generated from private key, in PEM format;
-  # only needed for use with real FAH servers, not testing;
-  # Required for refreshes of the `certificate_file` to be performed via API calls
-  fah_csr_file: "./path/to/fah-csr.pem"
+# URL of the FAH assignment server to use.
+fah_as_url: "https://assign1.foldingathome.org"
 
-  # Whether to verify SSL certificate presented by the FAH server.
-  fah_client_verify: True
+# URL of the FAH work server to use.
+fah_ws_url: "https://<my-work-server>.foldingathome.org"
 
-  # Interval in seconds to update the certificate used to authenticate with FAH servers;
-  # set to `null` to disable automatic cert renewal.
-  fah_cert_update_interval: 86400
+# Path to the TLS certificate to use for authentication with FAH servers;
+# required for real deployments.
+fah_certificate_file: "./path/to/fah-cert.pem"
 
-  # Path to leveldb index dir used by the service to track its state.
-  index_dir: "./path/to/index-dir"
+# Path to the RSA private key used for TLS communication with FAH servers;
+# required for real deployments.
+fah_key_file: "./path/to/fah-key.pem"
 
-  # Path to object store directory for larger objects, such as ProtocolDAGs.
-  obj_store: "./path/to/object-store"
+# Path to the certificate signing request (CSR) file generated from private key, in PEM format;
+# only needed for use with real FAH servers, not testing;
+# Required for refreshes of the `certificate_file` to be performed via API calls
+fah_csr_file: "./path/to/fah-csr.pem"
 
-  # List of FAH PROJECT (integer) ids that this compute service should use for executing compute.
-  fah_project_ids: []
+# Whether to verify SSL certificate presented by the FAH server.
+fah_client_verify: True
 
-  # Frequency in seconds between polls of FAH WS API for completed jobs.
-  fah_poll_interval: 60
+# Interval in seconds to update the certificate used to authenticate with FAH servers;
+# set to `null` to disable automatic cert renewal.
+fah_cert_update_interval: 86400
 
-  # List of supported core IDs in hex (base 16) format.  E.g. 0xa8.
-  fah_core_ids_supported: []
+# Path to leveldb index dir used by the service to track its state.
+index_dir: "./path/to/index-dir"
 
-# options for service execution
-start:
+# Path to object store directory for larger objects, such as ProtocolDAGs.
+obj_store: "./path/to/object-store"
 
-  # Max number of Tasks to execute before exiting. If `null`, the service will
-  # have no task limit.
-  max_tasks: null
+# List of FAH PROJECT (integer) ids that this compute service should use for executing compute.
+fah_project_ids: []
 
-  # Max number of seconds to run before exiting. If `null`, the service will
-  # have no time limit.
-  max_time: null
+# Frequency in seconds between polls of FAH WS API for completed jobs.
+fah_poll_interval: 60
+
+# List of supported core IDs in hex (base 16) format.  E.g. 0xa8.
+fah_core_ids_supported: []

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -339,17 +339,15 @@ The service handles ``SIGTERM`` and ``SIGINT`` signals for clean shutdown::
 
 By default, the service cleans up temporary directories. To retain them for debugging::
 
-    init:
-      keep_shared: True
-      keep_scratch: True
+    keep_shared: True
+    keep_scratch: True
 
 **Log Management:**
 
 Configure logging for operational monitoring::
 
-    init:
-      loglevel: "INFO"  # or DEBUG, WARN, ERROR
-      logfile: "./alchemiscale-fah.log"
+    loglevel: "INFO"  # or DEBUG, WARN, ERROR
+    logfile: "./alchemiscale-fah.log"
 
 Note that if writing to a log file, no file rotation is performed.
 The file will grow monotonically and without bound on its own for a long-running service.


### PR DESCRIPTION
## Summary

Mirrors **OpenFreeEnergy/alchemiscale#504**, which folds `max_tasks` and `max_time` into `ComputeServiceSettings`. Since `FahAsynchronousComputeServiceSettings` subclasses `ComputeServiceSettings`, the new fields are inherited automatically — no field additions needed here.

## Changes

- `FahAsynchronousComputeService.start()` reduced to `(self)`; reads limits from settings (cached in `__init__`).
- `alchemiscale-fah compute fah-asynchronous` CLI: loads a flat config (no `init:` / `start:` split).
- `devtools/configs/fah-asynchronous-compute-settings.yaml`: flattened; `max_tasks` / `max_time` folded in after `claim_limit`.
- Integration test fixture + references updated.
- Two `init:`-wrapped doc snippets in `deployment.rst` flattened.

## Required ordering

This is a **hard cutover** and depends on the upstream PR landing — `max_tasks` / `max_time` must exist on the parent `ComputeServiceSettings`, and the flattened YAML must be the format consumers expect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)