### PR TITLE
Set `compute_platform` to `None` as safeguard against requiring a GPU on work server

### DIFF
--- a/alchemiscale_fah/protocols/feflow/nonequilibrium_cycling.py
+++ b/alchemiscale_fah/protocols/feflow/nonequilibrium_cycling.py
@@ -158,6 +158,12 @@ class FahNonEquilibriumCyclingProtocol(NonEquilibriumCyclingProtocol):
         base_settings.integrator_settings.equilibrium_steps = 250000
         base_settings.integrator_settings.nonequilibrium_steps = 250000
 
+        # the default for this setting upstream is `CUDA`;
+        # setting it to `None` will use the fastest platform available on the host,
+        # and not raise an exception if a GPU is not present;
+        # this setting has no bearing on `openm-core` behavior downstream
+        base_settings.engine_settings.compute_platform = None
+
         fah_openmm_core_settings = FahOpenMMCoreSettings()
 
         # because this protocol does not minimize in its `SetupUnit`, we tell

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -62,7 +62,7 @@ For production use of this protocol, we recommend the default settings::
 
     >>> from alchemiscale_fah.protocols.feflow import FahNonEquilibriumCyclingProtocol
 
-    >>> settings = NonEquilibriumCyclingProtocol.default_settings()
+    >>> settings = FahNonEquilibriumCyclingProtocol.default_settings()
 
 These default settings will perform non-equilibrium cycling with a total simulation time of 4 ns for each cycle, starting with 1 ns of equilibrium sampling in state A, 1 ns of nonequilibrium sampling from state A to B, 1 ns of equilibrium sampling in state B, and finally 1 ns of nonequilibrium sampling from state B to A.
 


### PR DESCRIPTION
Ideally we don't run any operations that make use of this setting (see https://github.com/OpenFreeEnergy/feflow/pull/140), but as a guard against this we want to explicitly set `compute_platform` to `None` by default.
